### PR TITLE
ensure sensor, input, and output arguments are numeric.

### DIFF
--- a/check_hwgroup.py
+++ b/check_hwgroup.py
@@ -260,9 +260,9 @@ def commandline(args):
                       help='Critical threshold')
 
     SIO = argp.add_mutually_exclusive_group(required=True)
-    SIO.add_argument('-S', '--sensor', help='The sensor to check')
-    SIO.add_argument('-I', '--contact', help='The dry contact to checkThe sensor to')
-    SIO.add_argument('-O', '--output', help='The relay output to check')
+    SIO.add_argument('-S', '--sensor', type=int, help='The sensor to check')
+    SIO.add_argument('-I', '--contact', type=int, help='The dry contact to checkThe sensor to')
+    SIO.add_argument('-O', '--output', type=int, help='The relay output to check')
 
     return argp.parse_args(args)
 

--- a/test_check_hwgroup.py
+++ b/test_check_hwgroup.py
@@ -15,7 +15,7 @@ from check_hwgroup import CheckHWGroupError
 class CLITesting(unittest.TestCase):
 
     def test_commandline(self):
-        actual = commandline(['-H', 'localhost', '-C', 'foobar', '-w', '5', '-c', '10', '-S', 'sensor'])
+        actual = commandline(['-H', 'localhost', '-C', 'foobar', '-w', '5', '-c', '10', '-S', '216'])
         self.assertEqual(actual.host, 'localhost')
         self.assertEqual(actual.community, 'foobar')
         self.assertEqual(actual.critical, 10)


### PR DESCRIPTION
the latter are used for generating OID lookup keys, and the first is used for comparing with an integer value.